### PR TITLE
Add landing page and admin posts

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,11 +3,13 @@ import {
   getBlobUploadUrlsNoStore,
   getPhotosCountIncludingHiddenCached,
   getUniqueTagsCached,
+  getPostsCached,
 } from '@/cache';
 import {
   PATH_ADMIN_PHOTOS,
   PATH_ADMIN_TAGS,
   PATH_ADMIN_UPLOADS,
+  PATH_ADMIN_POSTS,
 } from '@/site/paths';
 
 export default async function AdminLayout({
@@ -19,10 +21,12 @@ export default async function AdminLayout({
     countPhotos,
     countUploads,
     countTags,
+    countPosts,
   ] = await Promise.all([
     getPhotosCountIncludingHiddenCached(),
     getBlobUploadUrlsNoStore().then(urls => urls.length),
     getUniqueTagsCached().then(tags => tags.length),
+    getPostsCached().then(posts => posts.length),
   ]);
 
   const navItemPhotos = {
@@ -43,10 +47,17 @@ export default async function AdminLayout({
     count: countTags,
   };
 
+  const navItemPosts = {
+    label: 'Posts',
+    href: PATH_ADMIN_POSTS,
+    count: countPosts,
+  };
+
   const navItems = [navItemPhotos];
 
   if (countUploads > 0) { navItems.push(navItemUploads); }
   if (countTags > 0) { navItems.push(navItemTags); }
+  navItems.push(navItemPosts);
 
   return (
     <div className="mt-4 space-y-5">

--- a/src/app/admin/posts/page.tsx
+++ b/src/app/admin/posts/page.tsx
@@ -1,0 +1,19 @@
+import PostForm from '@/post/PostForm';
+import { getAllPosts } from '@/post/actions';
+
+export default async function AdminPostsPage() {
+  const posts = await getAllPosts();
+  return (
+    <div className="space-y-6">
+      <PostForm />
+      <ul className="space-y-2">
+        {posts.map(post => (
+          <li key={post.id} className="border-b pb-2">
+            <div className="font-medium">{post.title}</div>
+            <div className="text-sm whitespace-pre-line">{post.content}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,16 @@
+import { getPosts } from '@/services/vercel-postgres';
+
+export default async function BlogPage() {
+  const posts = await getPosts();
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold mb-4">Blog</h1>
+      {posts.map(post => (
+        <article key={post.id} className="space-y-2">
+          <h2 className="text-xl font-semibold">{post.title}</h2>
+          <div className="whitespace-pre-line">{post.content}</div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,8 @@
+export default function ContactPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Contact</h1>
+      <p>You can reach me at <a className="underline" href="mailto:hello@mattdav.is">hello@mattdav.is</a>.</p>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,62 +1,14 @@
-import { getPhotosCached, getPhotosCountCached } from '@/cache';
-import AnimateItems from '@/components/AnimateItems';
-import MorePhotos from '@/photo/MorePhotos';
-import SiteGrid from '@/components/SiteGrid';
-import { generateOgImageMetaForPhotos } from '@/photo';
-import PhotoLarge from '@/photo/PhotoLarge';
-import PhotosEmptyState from '@/photo/PhotosEmptyState';
-import {
-  PaginationParams,
-  getPaginationForSearchParams,
-} from '@/site/pagination';
-import { pathForRoot } from '@/site/paths';
-import { Metadata } from 'next';
-import { MAX_PHOTOS_TO_SHOW_OG } from '@/photo/image-response';
-
-export const runtime = 'edge';
-
-export async function generateMetadata(): Promise<Metadata> {
-  // Make homepage queries resilient to error on first time setup
-  const photos = await getPhotosCached({ limit: MAX_PHOTOS_TO_SHOW_OG })
-    .catch(() => []);
-  return generateOgImageMetaForPhotos(photos);
-}
-
-export default async function HomePage({ searchParams }: PaginationParams) {
-  const { offset, limit } = getPaginationForSearchParams(searchParams, 12);
-
-  const [
-    photos,
-    count,
-  ] = await Promise.all([
-    // Make homepage queries resilient to error on first time setup
-    getPhotosCached({ limit }).catch(() => []),
-    getPhotosCountCached().catch(() => 0),
-  ]);
-  
-  const showMorePhotos = count > photos.length;
-
+export default function LandingPage() {
   return (
-    photos.length > 0
-      ? <div className="space-y-4">
-        <AnimateItems
-          className="space-y-1"
-          duration={0.7}
-          staggerDelay={0.15}
-          distanceOffset={0}
-          staggerOnFirstLoadOnly
-          items={photos.map((photo, index) =>
-            <PhotoLarge
-              key={photo.id}
-              photo={photo}
-              priority={index <= 1}
-            />)}
-        />
-        {showMorePhotos &&
-          <SiteGrid
-            contentMain={<MorePhotos path={pathForRoot(offset + 1)} />}
-          />}
-      </div>
-      : <PhotosEmptyState />
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6 text-center">
+      <h1 className="text-3xl font-bold">mattdav.is</h1>
+      <p>Welcome to my corner of the internet.</p>
+      <p className="flex gap-4">
+        <a href="/photos" className="underline">Photography</a>
+        <a href="/projects" className="underline">Projects</a>
+        <a href="/blog" className="underline">Blog</a>
+        <a href="/contact" className="underline">Contact</a>
+      </p>
+    </div>
   );
 }

--- a/src/app/photos/page.tsx
+++ b/src/app/photos/page.tsx
@@ -1,0 +1,62 @@
+import { getPhotosCached, getPhotosCountCached } from '@/cache';
+import AnimateItems from '@/components/AnimateItems';
+import MorePhotos from '@/photo/MorePhotos';
+import SiteGrid from '@/components/SiteGrid';
+import { generateOgImageMetaForPhotos } from '@/photo';
+import PhotoLarge from '@/photo/PhotoLarge';
+import PhotosEmptyState from '@/photo/PhotosEmptyState';
+import {
+  PaginationParams,
+  getPaginationForSearchParams,
+} from '@/site/pagination';
+import { pathForRoot } from '@/site/paths';
+import { Metadata } from 'next';
+import { MAX_PHOTOS_TO_SHOW_OG } from '@/photo/image-response';
+
+export const runtime = 'edge';
+
+export async function generateMetadata(): Promise<Metadata> {
+  // Make homepage queries resilient to error on first time setup
+  const photos = await getPhotosCached({ limit: MAX_PHOTOS_TO_SHOW_OG })
+    .catch(() => []);
+  return generateOgImageMetaForPhotos(photos);
+}
+
+export default async function HomePage({ searchParams }: PaginationParams) {
+  const { offset, limit } = getPaginationForSearchParams(searchParams, 12);
+
+  const [
+    photos,
+    count,
+  ] = await Promise.all([
+    // Make homepage queries resilient to error on first time setup
+    getPhotosCached({ limit }).catch(() => []),
+    getPhotosCountCached().catch(() => 0),
+  ]);
+  
+  const showMorePhotos = count > photos.length;
+
+  return (
+    photos.length > 0
+      ? <div className="space-y-4">
+        <AnimateItems
+          className="space-y-1"
+          duration={0.7}
+          staggerDelay={0.15}
+          distanceOffset={0}
+          staggerOnFirstLoadOnly
+          items={photos.map((photo, index) =>
+            <PhotoLarge
+              key={photo.id}
+              photo={photo}
+              priority={index <= 1}
+            />)}
+        />
+        {showMorePhotos &&
+          <SiteGrid
+            contentMain={<MorePhotos path={pathForRoot(offset + 1)} />}
+          />}
+      </div>
+      : <PhotosEmptyState />
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,16 @@
+import { getPosts } from '@/services/vercel-postgres';
+
+export default async function ProjectsPage() {
+  const posts = await getPosts(true);
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold mb-4">Projects</h1>
+      {posts.map(post => (
+        <article key={post.id} className="space-y-2">
+          <h2 className="text-xl font-semibold">{post.title}</h2>
+          <div className="whitespace-pre-line">{post.content}</div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -22,6 +22,7 @@ import {
   getPhotosFilmSimulationCount,
   getPhotosDateRange,
   getPhotosNearId,
+  getPosts,
 } from '@/services/vercel-postgres';
 import { parseCachedPhotoDates, parseCachedPhotosDates } from '@/photo';
 import { getBlobPhotoUrls, getBlobUploadUrls } from '@/services/blob';
@@ -208,6 +209,13 @@ export const getUniqueFilmSimulationsCached =
     getUniqueFilmSimulations,
     [KEY_PHOTOS, KEY_FILM_SIMULATIONS],
   );
+
+export const getPostsCached = (
+  project?: boolean,
+) => unstable_cache(
+  getPosts,
+  ['posts', project === undefined ? 'all' : project ? 'project' : 'nonproject']
+)(project);
 
 export const authCached = cache(auth);
 

--- a/src/post/PostForm.tsx
+++ b/src/post/PostForm.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState } from 'react';
+import SubmitButtonWithStatus from '@/components/SubmitButtonWithStatus';
+import { createPostAction } from './actions';
+
+export default function PostForm() {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [project, setProject] = useState(false);
+  return (
+    <form action={createPostAction} className="space-y-4">
+      <input
+        type="text"
+        name="title"
+        value={title}
+        onChange={e => setTitle(e.target.value)}
+        placeholder="Title"
+        className="w-full"
+        required
+      />
+      <textarea
+        name="content"
+        value={content}
+        onChange={e => setContent(e.target.value)}
+        placeholder="Content"
+        className="w-full h-40"
+        required
+      />
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          name="project"
+          checked={project}
+          onChange={e => setProject(e.target.checked)}
+        />
+        Project post
+      </label>
+      <SubmitButtonWithStatus>Create</SubmitButtonWithStatus>
+    </form>
+  );
+}

--- a/src/post/actions.ts
+++ b/src/post/actions.ts
@@ -1,0 +1,16 @@
+'use server';
+
+import { sqlInsertPost, getPosts } from '@/services/vercel-postgres';
+import { revalidatePath } from 'next/cache';
+import { PATH_ADMIN_POSTS } from '@/site/paths';
+import { nanoid } from 'nanoid';
+
+export async function createPostAction(formData: FormData) {
+  const title = formData.get('title') as string;
+  const content = formData.get('content') as string;
+  const project = formData.get('project') === 'on';
+  await sqlInsertPost({ id: nanoid(8), title, content, project });
+  revalidatePath(PATH_ADMIN_POSTS);
+}
+
+export const getAllPosts = async () => getPosts();

--- a/src/post/index.ts
+++ b/src/post/index.ts
@@ -1,0 +1,30 @@
+export type Post = {
+  id: string;
+  title: string;
+  content: string;
+  project?: boolean;
+  createdAt: string;
+};
+
+export type PostDb = {
+  id: string;
+  title: string;
+  content: string;
+  project: boolean | null;
+  created_at: string;
+};
+
+export type PostDbInsert = {
+  id: string;
+  title: string;
+  content: string;
+  project?: boolean;
+};
+
+export const parsePostFromDb = (row: PostDb): Post => ({
+  id: row.id,
+  title: row.title,
+  content: row.content,
+  project: row.project ?? undefined,
+  createdAt: row.created_at,
+});

--- a/src/site/NavClient.tsx
+++ b/src/site/NavClient.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import SiteGrid from '../components/SiteGrid';
 import { SITE_DOMAIN_OR_TITLE } from '@/site/config';
+import { PATH_HOME } from '@/site/paths';
 import ViewSwitcher, { SwitcherSelection } from '@/site/ViewSwitcher';
 import {
   PATH_ROOT,
@@ -68,8 +69,12 @@ export default function NavClient({
                   showAdmin={showAdmin}
                 />
               </div>
-              <div className="hidden xs:block">
-                {renderLink(SITE_DOMAIN_OR_TITLE, PATH_ROOT)}
+              <div className="hidden xs:flex gap-4 items-center">
+                {renderLink(SITE_DOMAIN_OR_TITLE, PATH_HOME)}
+                {renderLink('Photos', '/photos')}
+                {renderLink('Projects', '/projects')}
+                {renderLink('Blog', '/blog')}
+                {renderLink('Contact', '/contact')}
               </div>
             </div>]
             : []}

--- a/src/site/paths.ts
+++ b/src/site/paths.ts
@@ -8,7 +8,8 @@ import {
 import { FilmSimulation } from '@/simulation';
 
 // Core paths
-export const PATH_ROOT      = '/';
+export const PATH_HOME      = '/';
+export const PATH_ROOT      = '/photos';
 export const PATH_GRID      = '/grid';
 export const PATH_SETS      = '/sets';
 export const PATH_ADMIN     = '/admin';
@@ -31,6 +32,7 @@ const PATH_FILM_SIMULATION_DYNAMIC  = `${PREFIX_FILM_SIMULATION}/[simulation]`;
 export const PATH_ADMIN_PHOTOS        = `${PATH_ADMIN}/photos`;
 export const PATH_ADMIN_UPLOADS       = `${PATH_ADMIN}/uploads`;
 export const PATH_ADMIN_TAGS          = `${PATH_ADMIN}/tags`;
+export const PATH_ADMIN_POSTS         = `${PATH_ADMIN}/posts`;
 export const PATH_ADMIN_UPLOAD_BLOB   = `${PATH_ADMIN_UPLOADS}/blob`;
 export const PATH_ADMIN_CONFIGURATION = `${PATH_ADMIN}/configuration`;
 
@@ -44,6 +46,7 @@ export const PATHS_ADMIN = [
   PATH_ADMIN_PHOTOS,
   PATH_ADMIN_UPLOADS,
   PATH_ADMIN_TAGS,
+  PATH_ADMIN_POSTS,
   PATH_ADMIN_UPLOAD_BLOB,
   PATH_ADMIN_CONFIGURATION,
 ];


### PR DESCRIPTION
## Summary
- move original home page to `/photos`
- create landing page with basic navigation links
- implement rudimentary blog and projects functionality
- add admin page to create posts with a simple form
- extend database service for posts
- update navigation to link to new sections

## Testing
- `pnpm install`
- `pnpm test` *(fails: No tests found related to files changed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a373732c8322b1a1fdcefeac9b19