### PR TITLE
Fix DB auto-migrations and hide photo controls

### DIFF
--- a/__tests__/path.test.ts
+++ b/__tests__/path.test.ts
@@ -17,6 +17,7 @@ import {
   isPathTagPhoto,
   isPathTagPhotoShare,
   isPathTagShare,
+  isPathPhotoApp,
 } from '@/site/paths';
 import { getCameraFromKey } from '@/camera';
 
@@ -30,6 +31,8 @@ const SHARE           = 'share';
 const PATH_ROOT                         = '/';
 const PATH_GRID                         = '/grid';
 const PATH_ADMIN                        = '/admin/photos';
+const PATH_PROJECTS                     = '/projects';
+const PATH_PHOTOS                       = '/photos';
 
 const PATH_PHOTO                        = `/p/${PHOTO_ID}`;
 const PATH_PHOTO_SHARE                  = `${PATH_PHOTO}/${SHARE}`;
@@ -156,5 +159,12 @@ describe('Paths', () => {
     expect(getEscapePath(PATH_FILM_SIMULATION_SHARE)).toEqual(PATH_FILM_SIMULATION);
     expect(getEscapePath(PATH_FILM_SIMULATION_PHOTO)).toEqual(PATH_FILM_SIMULATION);
     expect(getEscapePath(PATH_FILM_SIMULATION_PHOTO_SHARE)).toEqual(PATH_FILM_SIMULATION_PHOTO);
+  });
+
+  it('identifies photo app paths', () => {
+    expect(isPathPhotoApp(PATH_PHOTOS)).toBe(true);
+    expect(isPathPhotoApp(PATH_GRID)).toBe(true);
+    expect(isPathPhotoApp(PATH_ADMIN)).toBe(true);
+    expect(isPathPhotoApp(PATH_PROJECTS)).toBe(false);
   });
 });

--- a/src/services/vercel-postgres.ts
+++ b/src/services/vercel-postgres.ts
@@ -308,6 +308,21 @@ const safelyQueryPhotos = async <T>(callback: () => Promise<T>): Promise<T> => {
       console.log('Creating table "photos" because it did not exist');
       await sqlCreatePhotosTable();
       result = await callback();
+    } else if (/column "hidden" does not exist/i.test(e.message)) {
+      console.log('Adding column "hidden" because it did not exist');
+      await db.query('ALTER TABLE photos ADD COLUMN hidden BOOLEAN');
+      result = await callback();
+    } else if (/column "taken_at_naive" does not exist/i.test(e.message)) {
+      console.log('Adding column "taken_at_naive" because it did not exist');
+      await db.query('ALTER TABLE photos ADD COLUMN taken_at_naive VARCHAR(255)');
+      await db.query(
+        "UPDATE photos SET taken_at_naive = to_char(taken_at AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') WHERE taken_at_naive IS NULL"
+      );
+      result = await callback();
+    } else if (/column "created_at" does not exist/i.test(e.message)) {
+      console.log('Adding column "created_at" because it did not exist');
+      await db.query('ALTER TABLE photos ADD COLUMN created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP');
+      result = await callback();
     } else if (/endpoint is in transition/i.test(e.message)) {
       // Wait 5 seconds and try again
       await new Promise(resolve => setTimeout(resolve, 5000));
@@ -334,6 +349,10 @@ const safelyQueryPosts = async <T>(callback: () => Promise<T>): Promise<T> => {
     if (/relation "posts" does not exist/i.test(e.message)) {
       console.log('Creating table "posts" because it did not exist');
       await sqlCreatePostsTable();
+      result = await callback();
+    } else if (/column "created_at" does not exist/i.test(e.message)) {
+      console.log('Adding column "created_at" to posts table');
+      await db.query('ALTER TABLE posts ADD COLUMN created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP');
       result = await callback();
     } else {
       console.log(`sql get error: ${e.message} `);

--- a/src/site/NavClient.tsx
+++ b/src/site/NavClient.tsx
@@ -14,6 +14,7 @@ import {
   isPathProtected,
   isPathSets,
   isPathSignIn,
+  isPathPhotoApp,
 } from '@/site/paths';
 import AnimateItems from '../components/AnimateItems';
 
@@ -27,6 +28,7 @@ export default function NavClient({
   const showNav = !isPathSignIn(pathname);
 
   const shouldAnimate = !isPathAdmin(pathname);
+  const showViewSwitcher = isPathPhotoApp(pathname);
 
   const renderLink = (
     text: string,
@@ -63,12 +65,12 @@ export default function NavClient({
                 'w-full min-h-[4rem]',
                 'leading-none',
               )}>
-              <div className="flex flex-grow items-center gap-4">
+              {showViewSwitcher && <div className="flex flex-grow items-center gap-4">
                 <ViewSwitcher
                   currentSelection={switcherSelectionForPath()}
                   showAdmin={showAdmin}
                 />
-              </div>
+              </div>}
               <div className="hidden xs:flex gap-4 items-center">
                 {renderLink(SITE_DOMAIN_OR_TITLE, PATH_HOME)}
                 {renderLink('Photos', '/photos')}

--- a/src/site/paths.ts
+++ b/src/site/paths.ts
@@ -250,6 +250,24 @@ export const isPathAdminConfiguration = (pathname?: string) =>
 export const isPathProtected = (pathname?: string) =>
   checkPathPrefix(pathname, PATH_ADMIN);
 
+export const isPathPhotoApp = (pathname?: string) =>
+  [PATH_ROOT, PATH_GRID, PATH_SETS].some(p => checkPathPrefix(pathname, p)) ||
+  isPathPhoto(pathname) ||
+  isPathPhotoShare(pathname) ||
+  isPathTag(pathname) ||
+  isPathTagShare(pathname) ||
+  isPathTagPhoto(pathname) ||
+  isPathTagPhotoShare(pathname) ||
+  isPathCamera(pathname) ||
+  isPathCameraShare(pathname) ||
+  isPathCameraPhoto(pathname) ||
+  isPathCameraPhotoShare(pathname) ||
+  isPathFilmSimulation(pathname) ||
+  isPathFilmSimulationShare(pathname) ||
+  isPathFilmSimulationPhoto(pathname) ||
+  isPathFilmSimulationPhotoShare(pathname) ||
+  isPathProtected(pathname);
+
 export const getPathComponents = (pathname = ''): {
   photoId?: string
   tag?: string


### PR DESCRIPTION
## Summary
- ensure missing columns are created automatically in Vercel Postgres services
- hide ViewSwitcher outside of photo app pages
- add `isPathPhotoApp` helper and tests

## Testing
- `pnpm install --ignore-scripts`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6840b60d4a9c8322a53f28defcb7aa57