### PR TITLE
Fix S3 copy logic and add DB migration

### DIFF
--- a/src/services/blob/aws-s3.ts
+++ b/src/services/blob/aws-s3.ts
@@ -57,18 +57,18 @@ export const awsS3Copy = async (
   fileNameDestination: string,
   addRandomSuffix?: boolean,
 ) => {
-  const name = fileNameSource.split('.')[0];
-  const extension = fileNameSource.split('.')[1];
+  const destName = fileNameDestination.split('.')[0];
+  const destExtension = fileNameDestination.split('.')[1] || fileNameSource.split('.')[1];
   const Key = addRandomSuffix
-    ? `${name}-${generateBlobId()}.${extension}`
+    ? `${destName}-${generateBlobId()}.${destExtension}`
     : fileNameDestination;
   return awsS3Client().send(new CopyObjectCommand({
     Bucket: AWS_S3_BUCKET,
-    CopySource: fileNameSource,
+    CopySource: `${AWS_S3_BUCKET}/${fileNameSource}`,
     Key,
     ACL: 'public-read',
   }))
-    .then(() => urlForKey(fileNameDestination));
+    .then(() => urlForKey(Key));
 };
 
 export const awsS3Delete = async (Key: string) => {

--- a/src/services/blob/index.ts
+++ b/src/services/blob/index.ts
@@ -64,7 +64,7 @@ export const convertUploadToPhoto = async (
   const useAwsS3 = HAS_AWS_S3_STORAGE && isUrlFromAwsS3(uploadUrl);
 
   const url = await (useAwsS3
-    ? awsS3Copy(uploadUrl, photoUrl, photoId === undefined)
+    ? awsS3Copy(fileNameForBlobUrl(uploadUrl), photoUrl, photoId === undefined)
     : vercelBlobCopy(uploadUrl, photoUrl, photoId === undefined));
 
   if (url) {

--- a/src/services/vercel-postgres.ts
+++ b/src/services/vercel-postgres.ts
@@ -312,6 +312,12 @@ const safelyQueryPhotos = async <T>(callback: () => Promise<T>): Promise<T> => {
       console.log('Adding column "hidden" because it did not exist');
       await db.query('ALTER TABLE photos ADD COLUMN hidden BOOLEAN');
       result = await callback();
+    } else if (/column "extension" does not exist/i.test(e.message)) {
+      console.log('Adding column "extension" because it did not exist');
+      await db.query(
+        "ALTER TABLE photos ADD COLUMN extension VARCHAR(255) NOT NULL DEFAULT 'jpg'"
+      );
+      result = await callback();
     } else if (/column "taken_at_naive" does not exist/i.test(e.message)) {
       console.log('Adding column "taken_at_naive" because it did not exist');
       await db.query('ALTER TABLE photos ADD COLUMN taken_at_naive VARCHAR(255)');


### PR DESCRIPTION
## Summary
- add fallback migration for the `extension` column in `photos`
- fix AWS copy helper to handle URL keys and return accurate URLs
- update upload helper to send S3 keys instead of full URLs

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npx jest` *(fails: Need to install the following packages: jest@29.7.0)*

------
https://chatgpt.com/codex/tasks/task_e_684330c1f5c0832288779b90ffdf116f